### PR TITLE
Added GC Detonators

### DIFF
--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_1000.et
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_1000.et
@@ -1,0 +1,16 @@
+GenericEntity : "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et" {
+ ID "508AB2013EEE1E00"
+ components {
+  SCR_DeployableInventoryItemInventoryComponent "{5222EB4D0C73006B}" {
+   Attributes SCR_ItemAttributeCollection "{5222EB4D0A2B466B}" {
+    ItemDisplayName UIInfo "{5222EB4D07D865FA}" {
+     Name "#AR-Item_M34BlastingMachine_Name (1000m)"
+     Description "#AR-Item_M34BlastingMachine_Description Modified by GC to operate up to 1000m."
+    }
+   }
+  }
+  SCR_DetonatorGadgetComponent "{5F1A794D87CB704C}" {
+   m_fMaxDetonationRange 1000
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_1000.et.meta
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_1000.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{510DC27BE4F52752}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_1000.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_250.et
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_250.et
@@ -1,0 +1,16 @@
+GenericEntity : "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et" {
+ ID "508AB2013EEE1E00"
+ components {
+  SCR_DeployableInventoryItemInventoryComponent "{5222EB4D0C73006B}" {
+   Attributes SCR_ItemAttributeCollection "{5222EB4D0A2B466B}" {
+    ItemDisplayName UIInfo "{5222EB4D07D865FA}" {
+     Name "#AR-Item_M34BlastingMachine_Name (250m)"
+     Description "#AR-Item_M34BlastingMachine_Description Modified by GC to operate up to 250m."
+    }
+   }
+  }
+  SCR_DetonatorGadgetComponent "{5F1A794D87CB704C}" {
+   m_fMaxDetonationRange 250
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_250.et.meta
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_250.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{ABE9DA7DDC1E1B24}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_250.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_500.et
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_500.et
@@ -1,0 +1,16 @@
+GenericEntity : "{CE0AF733722B3978}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_M34.et" {
+ ID "508AB2013EEE1E00"
+ components {
+  SCR_DeployableInventoryItemInventoryComponent "{5222EB4D0C73006B}" {
+   Attributes SCR_ItemAttributeCollection "{5222EB4D0A2B466B}" {
+    ItemDisplayName UIInfo "{5222EB4D07D865FA}" {
+     Name "#AR-Item_M34BlastingMachine_Name (500m)"
+     Description "#AR-Item_M34BlastingMachine_Description Modified by GC to operate up to 500m."
+    }
+   }
+  }
+  SCR_DetonatorGadgetComponent "{5F1A794D87CB704C}" {
+   m_fMaxDetonationRange 500
+  }
+ }
+}

--- a/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_500.et.meta
+++ b/Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_500.et.meta
@@ -1,0 +1,17 @@
+MetaFileClass {
+ Name "{0BE2E422211B0B6D}Prefabs/Items/Equipment/Detonators/BlastingMachine_M34/BlastingMachine_GC_M34_500.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+ }
+}


### PR DESCRIPTION
Added 3 items BlastingMachine_GC_M34_250, BlastingMachine_GC_M34_500, BlastingMachine_GC_M34_1000 which modifies base detonator from 100m range to 250m, 500m  and 1000m. In game Name and Description amended for players to be aware the range of their detonator (Not applicable to vanilla version).