### PR TITLE
Fix M249 sights to not use iron sights

### DIFF
--- a/Prefabs/Weapons/MachineGuns/M249/MG_M249_base.et
+++ b/Prefabs/Weapons/MachineGuns/M249/MG_M249_base.et
@@ -1,0 +1,12 @@
+GenericEntity : "{F54F6C453A8CB478}Prefabs/Weapons/Core/MachineGun_Base.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  WeaponComponent "{CFBAA4B706BA66E8}" {
+   components {
+    SightsComponent "{BB23A637957CFFF8}" {
+     SightsSwitchSkip 1
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/MachineGuns/M249/MG_M249_base.et.meta
+++ b/Prefabs/Weapons/MachineGuns/M249/MG_M249_base.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{599A1E833BEF3A43}Prefabs/Weapons/MachineGuns/M249/MG_M249_base.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Fixes the iron sights so that when a scope or other optic is on the M249, the iron sights are skipped over on the cycle process (like every other gun).