### PR TITLE
Add M1151(unarmed) vehicle prefabs and roof parts

### DIFF
--- a/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_olive.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_olive.et
@@ -1,0 +1,21 @@
+Vehicle : "{03708F7E58BB7A56}Prefabs/Vehicles/Wheeled/M998/M1151/M1151_armed_MK19.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
+   MultiSlots {
+    MultiSlotConfiguration "{66F2D69AD3FC9116}" {
+     SlotTemplate InventoryStorageSlot M2Ammo {
+      Prefab ""
+     }
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Roof {
+     Prefab "{0E8A755929850580}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_olive.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_olive.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F7E5F465159AD8D0}Prefabs/Vehicles/Wheeled/M998/M1151/M1151.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_tan.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_tan.et
@@ -1,0 +1,20 @@
+Vehicle : "{F7E5F465159AD8D0}Prefabs/Vehicles/Wheeled/M998/M1151/M1151_olive.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  MeshObject "{51DAA09FEFBFC0E7}" {
+   Materials {
+    MaterialAssignClass "{690978A7A4326598}" {
+     SourceMaterial "Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body"
+     AssignedMaterial "{ECFB0A86053379D8}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Tan.emat"
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Roof {
+     Prefab "{B4E080F726520522}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_tan.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M1151/M1151_tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{65D450A7F02074CA}Prefabs/Vehicles/Wheeled/M998/M1151/M1151_tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et
@@ -1,0 +1,13 @@
+GenericEntity : "{A3F113C69F7CFC56}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_Mk19.et" {
+ ID "672EDBFBD09A1100"
+ components {
+  SlotManagerComponent "{672EDBFBD09A1E84}" {
+   Slots {
+    RegisteringComponentSlotInfo Turret {
+     Offset 0 -0.4546 0.303
+     Prefab "{B901C89C8799C152}Prefabs/Vehicles/Wheeled/JLTV/VehParts/JLTV_Roof_Olive.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0E8A755929850580}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_tan.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_tan.et
@@ -1,0 +1,24 @@
+GenericEntity : "{0E8A755929850580}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof.et" {
+ ID "672EDBFBD09A1100"
+ components {
+  MeshObject "{672EDBFBD09A1EBE}" {
+   Materials {
+    MaterialAssignClass "{690978A770A4DE5D}" {
+     SourceMaterial "M1151A1_Armor_01"
+     AssignedMaterial "{BBD83E898B781E2A}Assets/Vehicles/Wheeled/M1151/Data/Armor_01/M1151A1_Armor_01_Tan.emat"
+    }
+    MaterialAssignClass "{690978A770A4DE49}" {
+     SourceMaterial "M1151A1_Armor_02"
+     AssignedMaterial "{80B049F4313279EB}Assets/Vehicles/Wheeled/M1151/Data/Armor_02/M1151A1_Armor_02_Tan.emat"
+    }
+   }
+  }
+  SlotManagerComponent "{672EDBFBD09A1E84}" {
+   Slots {
+    RegisteringComponentSlotInfo Turret {
+     Prefab "{53B38C68C388EF3D}Prefabs/Vehicles/Wheeled/JLTV/VehParts/JLTV_Roof_Base.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B4E080F726520522}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Introduce M1151 HMMWV prefabs: olive and tan variants, plus corresponding roof parts and meta files. Olive prefab includes inventory storage and a roof slot referencing GC_M1151_roof; tan prefab overrides body materials and points to a tan roof prefab. Roof parts add a turret slot (with offsets) and tan roof applies material assignments and alternate turret prefab. Meta files for each new entity template are included for platform configurations.