### PR TITLE
Add MK19 CROWS turrets, cages and weapon prefabs

### DIFF
--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et
@@ -1,0 +1,14 @@
+Vehicle : "{5F17F054025E8B30}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/Stryker_CROWS_Cage.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_UniversalInventoryStorageComponent "{5EAD79DA34C92091}" {
+   MultiSlots {
+    MultiSlotConfiguration "{60DE236EF75CAE7B}" {
+     SlotTemplate InventoryStorageSlot Ammo {
+      Prefab "{246807DD30734F3E}Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et"
+     }
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{126A563BC651CB66}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_MERDC.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_MERDC.et
@@ -1,0 +1,3 @@
+Vehicle : "{126A563BC651CB66}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et" {
+ ID "BBCBA43A9778AE21"
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_MERDC.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_MERDC.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{3DB98771063620A2}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_MERDC.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_Tan.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_Tan.et
@@ -1,0 +1,3 @@
+Vehicle : "{126A563BC651CB66}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19.et" {
+ ID "BBCBA43A9778AE21"
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_Tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_Tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{7402106241EE9814}Prefabs/Vehicles/Wheeled/Stryker/M1126/CROWS/MK19/Stryker_CROWS_Cage_MK19_Tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/Javelin/STRYKER_CROWS_Turret_Javelin.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/Javelin/STRYKER_CROWS_Turret_Javelin.et
@@ -1,0 +1,3 @@
+Turret : "{72AD3D7B02F0F450}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/STRYKER_CROWS_Turret.et" {
+ ID "51ACD0965653D003"
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/Javelin/STRYKER_CROWS_Turret_Javelin.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/Javelin/STRYKER_CROWS_Turret_Javelin.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{748F288C50DB7265}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/Javelin/STRYKER_CROWS_Turret_Javelin.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et
@@ -1,0 +1,18 @@
+Turret : "{72AD3D7B02F0F450}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/STRYKER_CROWS_Turret.et" {
+ ID "51ACD0965653D003"
+ components {
+  SlotManagerComponent "{62F2DDF02D357EBB}" {
+   Slots {
+    RegisteringComponentSlotInfo Magazine {
+     Prefab ""
+    }
+   }
+  }
+  WeaponSlotComponent "{51ACD09C6BFEEE6A}" {
+   AttachType InventoryStorageSlot "{0AACE7470E421D82}" {
+    Offset -0.1401 -0.2167 -0.0613
+   }
+   WeaponTemplate "{8536C17A0C9D2E64}Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et"
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{794397777BC5BF68}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19_Tan.et
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19_Tan.et
@@ -1,0 +1,11 @@
+Turret : "{794397777BC5BF68}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19.et" {
+ ID "51ACD0965653D003"
+ components {
+  SlotManagerComponent "{62F2DDF02D357EBB}" {
+   Slots {
+    RegisteringComponentSlotInfo Magazine {
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19_Tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19_Tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{FE0E131936792548}Prefabs/Vehicles/Wheeled/Stryker/VehParts/Turrets/MK19/STRYKER_CROWS_Turret_MK19_Tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et
+++ b/Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et
@@ -1,0 +1,14 @@
+GenericEntity : "{665EB9DBECC0B5F5}Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19_pintle_M1151.et" {
+ ID "476AE74DE20E1061"
+ components {
+  SlotManagerComponent "{68C2D10D10A7A478}" {
+   Enabled 0
+   Slots {
+    EntitySlotInfo Shield {
+     Offset -0.0024 -2.3875 -0.1654
+     Prefab "{68FB0651CDFA0FC4}Prefabs/Vehicles/Wheeled/IvecoLMV/VehParts/Turret/Gun_Shield_IvecoLMV_Tan.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et.meta
+++ b/Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{8536C17A0C9D2E64}Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Introduce MK19 CROWS assets for the Stryker: adds cage prefab with universal inventory ammo slot (references 40mm MK19 magazine) and platform variants (MERDC, Tan), MK19 turret prefabs (including Tan variant) and a Javelin CROWS turret alias, plus a GL_MK19 weapon prefab. Corresponding .meta files for each new entity are included. These additions wire the MK19 weapon template into the turret WeaponSlot and prepare vehicle/pintle configurations.