### PR TITLE
Add UH1H APKWS gunship prefab with the M134/M2HB

### DIFF
--- a/Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et
+++ b/Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et
@@ -1,0 +1,19 @@
+Vehicle : "{B358C5261525C945}Prefabs/Vehicles/Helicopters/UH1H/UH1H_armed_gunship_HE_sharkNose_APKWS.et" {
+ ID "5DB688595BAB2FD7"
+ components {
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo USArmyDecal {
+     Prefab ""
+    }
+    RegisteringComponentSlotInfo GunnerLeft {
+     Prefab "{E1B686BEA9631953}Prefabs/Vehicles/Helicopters/UH1H/VehParts/WeapSystems/UH1H_M134_gunner_left.et"
+    }
+    RegisteringComponentSlotInfo GunnerRight {
+     Prefab "{9E8DA08BB32F2E95}Prefabs/Vehicles/Helicopters/UH1H/VehParts/WeapSystems/UH1H_M2_gunner_right.et"
+    }
+   }
+  }
+ }
+ coords 10 0 0
+}

--- a/Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et.meta
+++ b/Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F45FB9574672416F}Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Add new prefab Prefabs/Vehicles/Helicopters/UH1H/GC_UH1H_armed_gunship_HE_sharkNose_APKWS_M2_M134.et and its .meta. The prefab registers a SlotManagerComponent with slots: USArmyDecal (empty), GunnerLeft (UH1H_M134_gunner_left), and GunnerRight (UH1H_M2_gunner_right)