### PR TITLE
Add AUS UH60 M240-armed prefabs

### DIFF
--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/GC_AUS_UH60_M240_armed.et
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/GC_AUS_UH60_M240_armed.et
@@ -1,0 +1,26 @@
+Vehicle : "{48F288F5BFF10D8B}Prefabs/Vehicles/Helicopters/AUS_MH60/AUS_UH60_armed.et" {
+ ID "5DB688595BAB2FD7"
+ components {
+  SCR_UniversalInventoryStorageComponent "{5E1E994304F0E0D3}" {
+   MultiSlots {
+    MultiSlotConfiguration "{60F686523ED8885E}" {
+     SlotTemplate InventoryStorageSlot MGammo {
+      Prefab "{96DD0591AFDCC579}Prefabs/Weapons/Magazines/Magazine_M240_Coax/Box_762x51_M240_coax_400rnd_4Ball_1Tracer.et"
+     }
+     NumSlots 6
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo GunnerLeft {
+     Prefab "{3C2BEC56D1CE805F}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et"
+    }
+    RegisteringComponentSlotInfo GunnerRight {
+     Prefab "{5DA5C670B2C0C1EC}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et"
+    }
+   }
+  }
+ }
+ coords 1.417 -0.388 -2.051
+}

--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/GC_AUS_UH60_M240_armed.et.meta
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/GC_AUS_UH60_M240_armed.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{29FAA5F138BD3C1B}Prefabs/Vehicles/Helicopters/AUS_MH60/GC_AUS_UH60_M240_armed.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et
@@ -1,0 +1,12 @@
+Turret : "{A2A1B4001EDCA44D}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M134_gunner_left.et" {
+ ID "51ACD0965653D003"
+ components {
+  WeaponSlotComponent "{51ACD09C6BFEEE6A}" {
+   AttachType InventoryStorageSlot "{0AACE7470E421D82}" {
+    Offset 0.0207 -0.2814 0.0234
+    Angles 0 -90 0
+   }
+   WeaponTemplate "{B51ADC7AA6FF62B9}Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et"
+  }
+ }
+}

--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et.meta
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{3C2BEC56D1CE805F}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_left.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et
@@ -1,0 +1,13 @@
+Turret : "{198E64980C247B8A}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M134_gunner_right.et" {
+ ID "51ACD0965653D003"
+ components {
+  WeaponSlotComponent "{51ACD09C6BFEEE6A}" {
+   AttachType InventoryStorageSlot "{0AACE7470E421D82}" {
+    Offset -0.0573 0.2756 -0.0462
+    Angles 0 90 180
+   }
+   WeaponTemplate "{B51ADC7AA6FF62B9}Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et"
+  }
+ }
+ coords 4.828 -0.244 -0.754
+}

--- a/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et.meta
+++ b/Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{5DA5C670B2C0C1EC}Prefabs/Vehicles/Helicopters/AUS_MH60/VehParts/WeapSystems/UH60_M240_gunner_right.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et
+++ b/Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et
@@ -1,0 +1,13 @@
+GenericEntity : "{2FE1AA46BCB6457D}Prefabs/Weapons/HeavyWeapons/MG_M240_pintle.et" {
+ ID "CFBAA4B725411E45"
+ components {
+  SlotManagerComponent "{656144AF9D771DAC}" {
+   Slots {
+    EntitySlotInfo Armor {
+     Prefab ""
+    }
+   }
+  }
+ }
+ coords 5.195 1.106 -0.755
+}

--- a/Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et.meta
+++ b/Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B51ADC7AA6FF62B9}Prefabs/Weapons/HeavyWeapons/GC_MG_M240_pintle_noarmor.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Introduce an M240-armed MH-60 variant and related parts. Adds GC_AUS_UH60_M240_armed vehicle prefab with an inventory storage config (6 MGammo slots using 400rnd M240 boxes) and two gunner slots referencing new left/right turret prefabs. Adds UH60_M240_gunner_left/right turret prefabs that attach the GC_MG_M240_pintle_noarmor weapon template with position/angle offsets, plus a no-armor M240 pintle weapon prefab. Includes corresponding .meta files for all new assets.