### PR TITLE
Fix for CRX hummvees M1025 M2HB gunshield material refs

### DIFF
--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et
@@ -3,9 +3,9 @@ Vehicle : "{3EA6F47D95867114}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB.et" 
  components {
   MeshObject "{51DAA09FEFBFC0E7}" {
    Materials {
-    MaterialAssignClass "{660E63924CCAB079}" {
+    MaterialAssignClass "{693B6C04F5D5BEEE}" {
      SourceMaterial "Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body"
-     AssignedMaterial "{8D4C03CFA3CBF98C}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_D_2004.emat"
+     AssignedMaterial "{1CE21568C5E2AC66}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body.emat"
     }
    }
   }
@@ -15,7 +15,7 @@ Vehicle : "{3EA6F47D95867114}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB.et" 
      Prefab "{2C06C17678E6FD7A}Prefabs/Vehicles/Wheeled/M998/VehParts/M998_tailgate_D_2004.et"
     }
     RegisteringComponentSlotInfo Roof {
-     Prefab "{71FFA1CF088DAB36}Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield_DESERT.et"
+     Prefab "{40410842456C4C6F}Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield.et"
     }
    }
   }

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et
@@ -1,10 +1,18 @@
 Vehicle : "{DD774A8FD0989A78}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB_MERDC.et" {
  ID "BBCBA43A9778AE21"
  components {
+  MeshObject "{51DAA09FEFBFC0E7}" {
+   Materials {
+    MaterialAssignClass "{555CC3777D2A9DEE}" {
+     SourceMaterial "Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body"
+     AssignedMaterial "{C4AB365990070417}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_USAF_D.emat"
+    }
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {
-     Prefab "{CEEF5B29CD014872}Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield_MERDC.et"
+     Prefab "{71FFA1CF088DAB36}Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield_DESERT.et"
     }
    }
   }

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_gun_mount_M2HB_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_gun_mount_M2HB_gunshield_DESERT.et
@@ -3,7 +3,7 @@ Turret : "{18343824C9D533CA}Prefabs/Vehicles/Wheeled/M998/VehParts/M1025_gun_mou
  components {
   MeshObject "{51ACD09C4E0B7D16}" {
    Materials {
-    MaterialAssignClass "{660E6392D7DE31C8}" {
+    MaterialAssignClass "{693B6C0626790316}" {
      SourceMaterial "Base"
      AssignedMaterial "{A139ED7073952BBE}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Roof_D_2004.emat"
     }

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/CRX_M1025_roof_M2HB_gunshield_DESERT.et
@@ -5,7 +5,11 @@ GenericEntity : "{AA4FACF008E134BF}Prefabs/Vehicles/Wheeled/M998/VehParts/M1025_
    Materials {
     MaterialAssignClass "{55DEA676C7D89FE4}" {
      SourceMaterial "Base"
-     AssignedMaterial "{A139ED7073952BBE}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Roof_D_2004.emat"
+     AssignedMaterial "{259C2F5F30065A2D}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Roof_Int_USAF_D.emat"
+    }
+    MaterialAssignClass "{693B6C0525CF1DC4}" {
+     SourceMaterial "HMMWV_Body_Roof_Int_38AD25796F1BEB94"
+     AssignedMaterial "{2CC2BB6BF01F3499}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Int_USAF_D.emat"
     }
    }
   }


### PR DESCRIPTION
### Overview
* Adjusted material assignments and roof prefab references for the M1025 M2HB gunshield and its parts.

### Specific Changes
* Updated `MaterialAssignClass` IDs and `AssignedMaterial` targets to use the correct HMMWV body/roof/emissive US/USAF desert materials.
* Added material blocks for the `DESERT` prefab.
* Switched the roof prefab reference to use the matching gunshield variants.

### Affected Files
* `CRX_M1025_armed_M2HB_gunshield.et`
* `CRX_M1025_armed_M2HB_gunshield_DESERT.et`
* `VehParts/CRX_M1025_gun_mount_M2HB_gunshield_DESERT.et`
* `VehParts/CRX_M1025_roof_M2HB_gunshield_DESERT.et`