### PR TITLE
Add editable UI info to M1025 gunshield prefabs

### DIFF
--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield.et
@@ -1,6 +1,11 @@
 Vehicle : "{6B0E98CE6921FCC2}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 KORD w/ Shield"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_DESERT.et
@@ -1,6 +1,12 @@
 Vehicle : "{C00B26E6C8808EF8}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 KORD w/ Shield Tan"
+    m_Image "{FAD448C478FE05C4}UI/Textures/EditorPreviews/Vehicles/Wheeled/M998/M1025_armed_M2HB_MDO_ION_D.edds"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_DESERT_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_DESERT_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{27D3611557F5B1E4}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_DESERT.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 KORD w/ GPK Tan"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{080A52884164EDB5}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_KORD_gunshield.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 KORD w/ GPK"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et
@@ -9,6 +9,11 @@ Vehicle : "{3EA6F47D95867114}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB.et" 
     }
    }
   }
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M1025_M2_Name w/ Shield"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Tailgate {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et
@@ -9,6 +9,12 @@ Vehicle : "{DD774A8FD0989A78}Prefabs/Vehicles/Wheeled/M998/M1025_armed_M2HB_MERD
     }
    }
   }
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M1025_M2_Name w/ Shield Tan"
+    m_Image "{F03CD7481B7E9EE5}UI/Textures/EditorPreviews/Vehicles/m998/M1025_armed_M2HB_MDO_USAF_D.edds"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{C00B26E6C8808EF8}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M1025_M2_Name w/ GPK Tan"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{6B0E98CE6921FCC2}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_M1025_M2_Name w/ GPK"
+   }
+  }
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Roof {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield.et
@@ -1,6 +1,11 @@
 Vehicle : "{6B0E98CE6921FCC2}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 MK19 w/ Shield"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_DESERT.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_DESERT.et
@@ -1,6 +1,11 @@
 Vehicle : "{C00B26E6C8808EF8}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_M2HB_gunshield_DESERT.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 MK19  w/ Shield Tan"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_DESERT_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_DESERT_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{8CE4011B6B6BDAD7}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_DESERT.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 MK19  w/ GPK Tan"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {

--- a/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_GPK.et
+++ b/Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield_GPK.et
@@ -1,6 +1,11 @@
 Vehicle : "{41033FD6FEC127E4}Prefabs/Vehicles/Wheeled/M998/CRX_M1025_armed_MK19_gunshield.et" {
  ID "BBCBA43A9778AE21"
  components {
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableVehicleUIInfo "{5298E609432D192D}" {
+    Name "M1025 MK19 w/ GPK"
+   }
+  }
   SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
    MultiSlots {
     MultiSlotConfiguration "{5B1070686F48F485}" {


### PR DESCRIPTION
Add SCR_EditableVehicleComponent blocks with m_UIInfo Name entries (and preview images for desert variants) to M1025 armed gunshield prefabs (KORD, M2HB, MK19 and their DESERT/GPK variants). This provides readable editor display names and thumbnails for these vehicle prefabs, improving identification in the editor. M2HB variants use a localization token for the base name where appropriate.