### PR TITLE
Add unarmed BRDM2 vehicle prefab

### DIFF
--- a/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et
+++ b/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et
@@ -1,0 +1,14 @@
+Vehicle : "{532B5F3CF8496E59}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_base.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Turret {
+     Offset 0 -0.4884 0.5751
+     Prefab "{B901C89C8799C152}Prefabs/Vehicles/Wheeled/JLTV/VehParts/JLTV_Roof_Olive.et"
+    }
+   }
+  }
+ }
+ coords 0 0 0.075
+}

--- a/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et.meta
+++ b/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{8EED8657762F7B9A}Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Introduce an unarmed BRDM2 entity template and its metadata. Adds Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et which extends BRDM2_base, registers a Turret Slot (using JLTV_Roof_Olive prefab) and sets local coords. Includes corresponding .meta file with platform configurations.