### PR TITLE
Update BRDM2 unarmed prefab and turret offset

### DIFF
--- a/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et
+++ b/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et
@@ -1,14 +1,14 @@
-Vehicle : "{532B5F3CF8496E59}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2_base.et" {
+Vehicle : "{254289B9C09904AB}Prefabs/Vehicles/Wheeled/BRDM2/BRDM2.et" {
  ID "BBCBA43A9778AE21"
  components {
   SlotManagerComponent "{55BCE45E438E4CFF}" {
    Slots {
     RegisteringComponentSlotInfo Turret {
-     Offset 0 -0.4884 0.5751
+     Offset 0 -0.489 0.5373
      Prefab "{B901C89C8799C152}Prefabs/Vehicles/Wheeled/JLTV/VehParts/JLTV_Roof_Olive.et"
     }
    }
   }
  }
- coords 0 0 0.075
+ coords 0 1.036 0
 }

--- a/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et.meta
+++ b/Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{8EED8657762F7B9A}Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed.et"
+ Name "{1D8B8FF2AC498A20}Prefabs/Vehicles/Wheeled/BRDM2/GC_BRDM2_unarmed_2.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }


### PR DESCRIPTION
Switch the vehicle base prefab to BRDM2.et and update metadata name; adjust turret slot positioning and vehicle coords to correct roof/turret placement. Key changes: base prefab reference and GUID updated, Turret Offset changed from (0 -0.4884 0.5751) to (0 -0.489 0.5373), and coords changed from (0 0 0.075) to (0 1.036 0). Meta Name updated to the new resource name ending in _2.et.