### PR TITLE
Add M998 vehicle prefabs and turret parts

### DIFF
--- a/Prefabs/Vehicles/Wheeled/M998/GC_M998T_covered.et
+++ b/Prefabs/Vehicles/Wheeled/M998/GC_M998T_covered.et
@@ -1,0 +1,270 @@
+Vehicle : "{B55C6990A6A9411B}Prefabs/Vehicles/Wheeled/M998/M998_covered.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_BaseCompartmentManagerComponent "{20FB66C5DCB8DF72}" {
+   DoorInfoList {
+    CompartmentDoorInfo "{696119A28459F8ED}" {
+     AnimDoorIndex 4
+     ContextName "Rear_entry"
+     EntryPositionInfo PointInfo "{696119A2A5FB3CD5}" {
+      PivotID "v_door_rear"
+      Offset -0.4345 -0.7313 -0.5001
+     }
+     ExitPositionInfo PointInfo "{696119A2A35DFDCE}" {
+      PivotID "v_door_rear"
+      Offset -0.7508 -0.2761 -0.8848
+     }
+     GetInTeleport 1
+     GetOutTeleport 1
+     AccessibilitySettings CompartmentAccessibilityContext "{696119A2B84212AF}" {
+     }
+    }
+   }
+   CompartmentSlots {
+    CargoCompartmentSlot Pass_Rear_L1 : Passenger_r02 {
+     DefaultOccupantName ""
+     CompartmentAction SCR_GetInUserAction "{5086CC2FCCAA457D}" {
+      ParentContextList +{
+      }
+     }
+     AdditionalActions {
+      SCR_RemoveCasualtyUserAction "{5D528255CC646B68}" {
+       ParentContextList +{
+       }
+      }
+      SCR_RemoveCasualtyUserAction "{61089D5E00C44348}" {
+      }
+     }
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset -1.5273 0.423 -0.9361
+      Angles 0 94.095 0
+     }
+     EjectUnconsciousAndDeadCharacters 0
+     CharacterHasCollision 0
+     DoorInfoList +{
+     }
+     BaseCoverage 0.15
+    }
+    CargoCompartmentSlot Rear_left_1 {
+     DefaultOccupantName "Rear_left_1"
+     CompartmentAction SCR_GetInUserAction "{696119A914324DBE}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFA0148350}" {
+       Name "Get in"
+      }
+     }
+     GetOutAction SCR_GetOutAction "{696119A81A73F6C0}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFB0955651}" {
+       Name "Get out"
+      }
+     }
+     JumpOutAction SCR_JumpOutAction "{696119A8154EFA0E}" {
+     }
+     SwitchSeatAction SCR_SwitchSeatAction "{696119A8135D891F}" {
+      ParentContextList {
+      }
+      UIInfo UIInfo "{696119AFC6595355}" {
+       Name "Switch seat"
+      }
+     }
+     AdditionalActions {
+      SCR_RemoveCasualtyUserAction "{696119A914324DA3}" {
+       ParentContextList {
+        "Rear_hatch"
+       }
+       UIInfo UIInfo "{696119AE5FFCCAD7}" {
+        Name "Remove casualtiy"
+       }
+      }
+     }
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset -0.7419 1.2866 -1.5889
+      Angles 0 89.7345 0
+      Prefab ""
+     }
+     EjectUnconsciousAndDeadCharacters 1
+     SeatType 3
+     DoorInfoList {
+      4
+     }
+     BaseCoverage 0.15
+    }
+    CargoCompartmentSlot Rear_right_1 {
+     DefaultOccupantName "Rear_right_1"
+     CompartmentAction SCR_GetInUserAction "{5086CC2FCCAA457D}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFDB2E926D}" {
+       Name "Get in"
+      }
+     }
+     GetOutAction SCR_GetOutAction "{696119A82C84F1FF}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFD3376AB4}" {
+       Name "Get out"
+      }
+     }
+     JumpOutAction SCR_JumpOutAction "{696119A82AEE5772}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+     }
+     SwitchSeatAction SCR_SwitchSeatAction "{696119A8289210BC}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFEA37763A}" {
+       Name "Switch seat"
+      }
+      ActionTitle "Switch seat"
+     }
+     AdditionalActions {
+      SCR_RemoveCasualtyUserAction "{5D528255CC646B68}" {
+       ParentContextList {
+        "Rear_hatch"
+       }
+       UIInfo UIInfo "{696119AE4C6A49A7}" {
+        Name "Remove casualtiy"
+       }
+      }
+     }
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset 0.7842 1.2744 -1.5486
+      Angles 0 -89.5304 0
+     }
+     EjectUnconsciousAndDeadCharacters 1
+     SeatType 3
+     DoorInfoList {
+      4
+     }
+     BaseCoverage 0.15
+    }
+    CargoCompartmentSlot Rear_right_2 {
+     DefaultOccupantName "Rear_right_2"
+     CompartmentAction SCR_GetInUserAction "{5086CC2FCCAA457D}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFFCE1DC75}" {
+       Name "Get in"
+      }
+     }
+     GetOutAction SCR_GetOutAction "{696119A82797C1F7}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFF97A9AE3}" {
+       Name "Get out"
+      }
+     }
+     JumpOutAction SCR_JumpOutAction "{696119A82404D95A}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+     }
+     SwitchSeatAction SCR_SwitchSeatAction "{696119A822A37668}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AFF0E8D6C8}" {
+       Name "Switch seat"
+      }
+     }
+     AdditionalActions {
+      SCR_RemoveCasualtyUserAction "{5D528255CC646B68}" {
+       ParentContextList {
+        "Rear_hatch"
+       }
+       UIInfo UIInfo "{696119AE04B09300}" {
+        Name "Remove casualtiy"
+       }
+      }
+     }
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset 0.7798 1.2744 -2.0795
+      Angles 0 -89.5304 0
+     }
+     EjectUnconsciousAndDeadCharacters 1
+     SeatType 3
+     DoorInfoList {
+      4
+     }
+     BaseCoverage 0.15
+    }
+    CargoCompartmentSlot Rear_left_2 {
+     DefaultOccupantName "Rear_left_2"
+     CompartmentAction SCR_GetInUserAction "{5086CC2FCCAA457D}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AE29418E73}" {
+       Name "Get in"
+      }
+     }
+     GetOutAction SCR_GetOutAction "{696119A820739E9E}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AE2C6D2FBF}" {
+       Name "Get out"
+      }
+     }
+     JumpOutAction SCR_JumpOutAction "{696119A83E9BC929}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+     }
+     SwitchSeatAction SCR_SwitchSeatAction "{696119A83F2B702E}" {
+      ParentContextList {
+       "Rear_hatch"
+      }
+      UIInfo UIInfo "{696119AE16758E3F}" {
+       Name "Switch seat"
+      }
+     }
+     AdditionalActions {
+      SCR_RemoveCasualtyUserAction "{5D528255CC646B68}" {
+       ParentContextList {
+        "Rear_hatch"
+       }
+       UIInfo UIInfo "{696119AE1AEF561C}" {
+        Name "Remove casualtiy"
+       }
+      }
+     }
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset -0.7614 1.2598 -2.1435
+      Angles 0 88.4191 0
+     }
+     EjectUnconsciousAndDeadCharacters 1
+     SeatType 3
+     DoorInfoList {
+      4
+     }
+     BaseCoverage 0.15
+    }
+   }
+   m_bBlockSuppliesIfOccupied 1
+  }
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   ActionContexts {
+    UserActionContext "{696119A57BB2F31C}" {
+     ContextName "Rear_hatch"
+     Position PointInfo "{696119A573900878}" {
+      PivotID "v_door_rear"
+      Offset -0.5013 0.2096 0
+     }
+     Radius 0.51
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/GC_M998T_covered.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/GC_M998T_covered.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{AD1557D294604BF9}Prefabs/Vehicles/Wheeled/M998/M998_covered.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et
@@ -1,0 +1,23 @@
+Vehicle : "{256CF92D598E7163}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_base.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
+   MultiSlots {
+    MultiSlotConfiguration "{696119814209E9FE}" {
+     SlotTemplate InventoryStorageSlot M2HBrnds {
+      Prefab "{C820846B0521423B}Prefabs/Weapons/Magazines/Box_127x99_M2_100rnd_4AP_1APIT.et"
+     }
+     NumSlots 8
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Rollbar {
+     Prefab "{1A889B8C00BD9498}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et"
+    }
+   }
+  }
+ }
+ coords 1.902 -2.026 0.96
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{D41D9CB52F3597EB}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2_tan.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2_tan.et
@@ -1,0 +1,28 @@
+Vehicle : "{D41D9CB52F3597EB}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  MeshObject "{51DAA09FEFBFC0E7}" {
+   Materials {
+    MaterialAssignClass "{696119841A73A641}" {
+     SourceMaterial "Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body"
+     AssignedMaterial "{C4AB365990070417}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_USAF_D.emat"
+    }
+    MaterialAssignClass "{696119841A73A66B}" {
+     SourceMaterial "HMMWV_Body_Details_Int_1C96436D98233F41"
+     AssignedMaterial "{2CC2BB6BF01F3499}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Int_USAF_D.emat"
+    }
+    MaterialAssignClass "{696119841A73A664}" {
+     SourceMaterial "HMMWV_Body_Int_1C7B4ACE653D9BD1"
+     AssignedMaterial "{2CC2BB6BF01F3499}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Int_USAF_D.emat"
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Tailgate {
+     Prefab "{043F0CF18FDEB7B7}Prefabs/Vehicles/Wheeled/M998/VehParts/M998_tailgate_USAF_D.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2_tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2_tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B9F3154C22DE7C55}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2_tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et
@@ -1,0 +1,22 @@
+Vehicle : "{D41D9CB52F3597EB}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_M2.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  SCR_UniversalInventoryStorageComponent "{5916C587FC993363}" {
+   MultiSlots {
+    MultiSlotConfiguration "{69611981395A1329}" {
+     SlotTemplate InventoryStorageSlot Mk19rnds {
+      Prefab "{246807DD30734F3E}Prefabs/Weapons/Magazines/MK_19/Magazine_40mm_MK19_48rnd_Base.et"
+     }
+     NumSlots 8
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Rollbar {
+     Prefab "{BAA25E10F5508AF5}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{1C69770181D1D8EA}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19_tan.et
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19_tan.et
@@ -1,0 +1,28 @@
+Vehicle : "{1C69770181D1D8EA}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19.et" {
+ ID "BBCBA43A9778AE21"
+ components {
+  MeshObject "{51DAA09FEFBFC0E7}" {
+   Materials {
+    MaterialAssignClass "{69611984155CC2AE}" {
+     SourceMaterial "Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body"
+     AssignedMaterial "{C4AB365990070417}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_USAF_D.emat"
+    }
+    MaterialAssignClass "{69611984155CCD54}" {
+     SourceMaterial "HMMWV_Body_Details_Int_1C96436D98233F41"
+     AssignedMaterial "{2CC2BB6BF01F3499}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Int_USAF_D.emat"
+    }
+    MaterialAssignClass "{69611984155CCD4C}" {
+     SourceMaterial "HMMWV_Body_Int_1C7B4ACE653D9BD1"
+     AssignedMaterial "{2CC2BB6BF01F3499}Assets/Vehicles/Wheeled/M998/Data/HMMWV_Body_Int_USAF_D.emat"
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo Tailgate {
+     Prefab "{043F0CF18FDEB7B7}Prefabs/Vehicles/Wheeled/M998/VehParts/M998_tailgate_USAF_D.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19_tan.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19_tan.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{4A1B709F91DA239B}Prefabs/Vehicles/Wheeled/M998/M998_uncovered_Pintle_Mk19_tan.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et
@@ -1,0 +1,41 @@
+GenericEntity : "{03DBD65A6A91E23B}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_M1151_roof_M2HB.et" {
+ ID "672EDBFBD09A1100"
+ components {
+  MeshObject "{672EDBFBD09A1EBE}" {
+   Object "{E3C54966F779B3D1}Assets/Vehicles/Wheeled/M998/VehParts/M998_Rollbar.xob"
+  }
+  SlotManagerComponent "{672EDBFBD09A1E84}" {
+   Slots {
+    RegisteringComponentSlotInfo Window_LR {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_RR {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_RF {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_LF {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Turret {
+     Offset 0 1.9703 -0.2388
+     Prefab "{8A8BB68F07C1B5A0}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et"
+    }
+    RegisteringComponentSlotInfo Window_LF2 {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_LR2 {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_RF2 {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo Window_RR2 {
+     Enabled 0
+    }
+   }
+  }
+ }
+ coords 0 0.277 0
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{1A889B8C00BD9498}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et
@@ -1,0 +1,13 @@
+GenericEntity : "{1A889B8C00BD9498}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_M2HB.et" {
+ ID "672EDBFBD09A1100"
+ components {
+  SlotManagerComponent "{672EDBFBD09A1E84}" {
+   Slots {
+    RegisteringComponentSlotInfo Turret {
+     Offset 0 1.7849 -0.2282
+     Prefab "{8BAFC4DF6AA587F2}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et"
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{BAA25E10F5508AF5}Prefabs/Vehicles/Wheeled/M998/VehParts/GC_m988_rollbar_Mk19.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et
@@ -1,0 +1,35 @@
+Turret : "{DB71EA71A5802162}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/M1151_GPK_M134.et" {
+ ID "51ACD0965653D003"
+ components {
+  MeshObject "{51ACD09C4E0B7D16}" {
+   Object "{3432051903D69544}Assets/Empty/empty.xob"
+   Materials {
+    MaterialAssignClass "{69617254E3E9CFAE}" {
+     SourceMaterial "GPK"
+     AssignedMaterial "{720F79D28204104E}Assets/Vehicles/Wheeled/M1151/Data/GPK.emat"
+    }
+   }
+  }
+  SCR_BaseCompartmentManagerComponent "{51ACFBB07A14CFA6}" {
+   CompartmentSlots {
+    TurretCompartmentSlot TurretCompartment {
+     PassengerPositionInfo EntitySlotInfo "{B1CB25848A3D93A8}" {
+      PivotID ""
+      Offset -0.0022 -0.9375 -1.0009
+     }
+    }
+   }
+  }
+  TurretControllerComponent "{51ACD09C61C183E4}" {
+   HasMoveableBase 0
+   LimitsHoriz -30 30
+  }
+  WeaponSlotComponent "{51ACD09C6BFEEE6A}" {
+   AttachType InventoryStorageSlot "{0AACE7470E421D82}" {
+    Offset 0.0154 -0.0159 0.0571
+   }
+   WeaponTemplate "{E517E6CCC1DF5737}Prefabs/Weapons/HeavyWeapons/HMG_M2HB_pintle_M1025.et"
+  }
+ }
+ coords 1.866 -0.035 0.734
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{8A8BB68F07C1B5A0}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/M1151_GPK_KORD_pintletest.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et
@@ -1,0 +1,8 @@
+Turret : "{8A8BB68F07C1B5A0}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_M2HB.et" {
+ ID "51ACD0965653D003"
+ components {
+  WeaponSlotComponent "{51ACD09C6BFEEE6A}" {
+   WeaponTemplate "{8536C17A0C9D2E64}Prefabs/Weapons/HeavyWeapons/MK19/GL_MK19.et"
+  }
+ }
+}

--- a/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et.meta
+++ b/Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{8BAFC4DF6AA587F2}Prefabs/Vehicles/Wheeled/M998/VehParts/Turrets/GC_m988_pintle_Mk19_2.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Introduce M998 vehicle prefabs and associated parts: covered variant and multiple uncovered pintle variants (M2, MK19) including tan material variants. Add rollbar and turret prefabs (M2HB, MK19) with weapon/slot configurations and inventory/magazine multi-slot setups, plus tailgate and slot manager entries. Includes corresponding .meta files for platform configurations.