### PR TITLE
Switch insurgent boots and normalize sapper labels

### DIFF
--- a/Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Character_GC_INSURGENT_Rifleman.et
+++ b/Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Character_GC_INSURGENT_Rifleman.et
@@ -39,7 +39,7 @@ SCR_ChimeraCharacter : "{DE3786C0C6C978D4}Prefabs/Characters/Factions/INDFOR/FIA
      Prefab "{713E6F2FF25DCD87}Prefabs/Characters/Uniforms/Pants_Cargo_1.et"
     }
     LoadoutSlotInfo Boots {
-     Prefab "{64B94D8A4D92A4BD}Prefabs/Characters/Footwear/Boots_Altama/Footwear_Altama.et"
+     Prefab "{B12C47DF95EC9C17}Prefabs/Characters/Footwear/CombatBoots_Insurgents.et"
     }
     LoadoutSlotInfo Vest {
      Prefab "{2835A0EA3B79E63E}Prefabs/Characters/Vests/Vest_ALICE/Variants/Vest_ALICE_rifleman.et"

--- a/Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Character_GC_INSURGENT_Sapper.et
+++ b/Prefabs/Characters/Factions/OPFOR/GC_INSURGENT/Character_GC_INSURGENT_Sapper.et
@@ -15,7 +15,7 @@ SCR_ChimeraCharacter : "{DE3786C0C6C978D4}Prefabs/Characters/Factions/INDFOR/FIA
     m_Image "{6601A3AE17EA976D}UI/Textures/EditorPreviews/Characters/INDFOR/FIA/Character_FIA_Rifleman.edds"
     m_sFaction "GC_INSURGENT"
     m_aAutoLabels {
-     122 46
+     SIZE_M ROLE_RIFLEMAN
     }
    }
   }
@@ -39,7 +39,7 @@ SCR_ChimeraCharacter : "{DE3786C0C6C978D4}Prefabs/Characters/Factions/INDFOR/FIA
      Prefab "{C5C2320E37105CF5}Prefabs/Characters/Uniforms/Pants_Cargo_4.et"
     }
     LoadoutSlotInfo Boots {
-     Prefab "{64B94D8A4D92A4BD}Prefabs/Characters/Footwear/Boots_Altama/Footwear_Altama.et"
+     Prefab "{B12C47DF95EC9C17}Prefabs/Characters/Footwear/CombatBoots_Insurgents.et"
     }
     LoadoutSlotInfo Back {
      Prefab "{752C6BCDF74E4169}Prefabs/Items/Equipment/Backpacks/Backpack_Small.et"


### PR DESCRIPTION
Replace Altama boots with CombatBoots_Insurgents for GC_INSURGENT Rifleman and Sapper prefabs to unify footwear across insurgent characters. Also replace numeric auto-labels in the Sapper prefab ("122 46") with named labels (SIZE_M ROLE_RIFLEMAN) for clarity and maintainability. Files changed: Character_GC_INSURGENT_Rifleman.et, Character_GC_INSURGENT_Sapper.et.