### PR TITLE
Updated TOW Missile

### DIFF
--- a/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et
+++ b/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et
@@ -1,0 +1,16 @@
+Projectile : "{C0BDA86B5AA5648C}Prefabs/Weapons/Core/Ammo_Rocket_Base.et" {
+ ID "DA5C6308000CDEF2"
+ components {
+  MissileMoveComponent "{0EF36690881261EF}" {
+   InitSpeed 30
+   ThrustTime 1.6
+   ThrustForce 5000
+   ForwardAirFriction 0.2
+  }
+  TF_SACLOS_MissileMovement "{672B1EF73F10901E}" {
+   m_SteerSmooth 1.2
+   m_MaxSteerAngle 15
+   m_MaxAngularSpeed 5
+  }
+ }
+}

--- a/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et
+++ b/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et
@@ -3,12 +3,14 @@ Projectile : "{C0BDA86B5AA5648C}Prefabs/Weapons/Core/Ammo_Rocket_Base.et" {
  components {
   MissileMoveComponent "{0EF36690881261EF}" {
    InitSpeed 30
+   TimeToLive 21
    ThrustTime 1.6
-   ThrustForce 5000
+   ThrustForce 4400
    ForwardAirFriction 0.2
   }
   TF_SACLOS_MissileMovement "{672B1EF73F10901E}" {
-   m_SteerSmooth 1.2
+   m_SteerRate 6
+   m_SteerSmooth 1
    m_MaxSteerAngle 15
    m_MaxAngularSpeed 5
   }

--- a/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et.meta
+++ b/Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{5699CC7CBA999734}Prefabs/Weapons/HeavyWeapons/BGM71TOW/Ammo_Rocket_BGM-71D.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
Adds an Override on Tactical Flava Tow Missles
- Missile achieves 300 m/s within 1.6 seconds of departing the tube (Thrust Force increased from 1500 to 5000 N, Thrust time reduced from 23 s to 1.6 s)
- Reduced missile smoothing to steer better.
- Reduced Air friction so missile can glide better.
- Increased Max Steer Angle to 15 degrees
- Max Angular Speed reduced to 5
