### PR TITLE
Replaces Warsaw Pact red tracers with green tracers

### DIFF
--- a/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_APFSDST_3BM60.et
+++ b/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_APFSDST_3BM60.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "476AE74C1F2F140D"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_APFSDST_3BM60.et.meta
+++ b/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_APFSDST_3BM60.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0B8F249CF243D60C}Prefabs/Weapons/Ammo/125mm/Ammo_125mm_APFSDST_3BM60.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_HE_FRAG_3OF26.et
+++ b/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_HE_FRAG_3OF26.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "476AE74C1F2F140D"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_HE_FRAG_3OF26.et.meta
+++ b/Prefabs/Weapons/Ammo/125mm/Ammo_125mm_HE_FRAG_3OF26.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{998C09D3475C29BE}Prefabs/Weapons/Ammo/125mm/Ammo_125mm_HE_FRAG_3OF26.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_APT_3UBR6.et
+++ b/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_APT_3UBR6.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "476AE74AA8E99E2E"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_APT_3UBR6.et.meta
+++ b/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_APT_3UBR6.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{5A2E0AD043840F2A}Prefabs/Weapons/Ammo/30x165/Ammo_30mm_APT_3UBR6.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_HEFT_3UOR6.et
+++ b/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_HEFT_3UOR6.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_HEFT_3UOR6.et.meta
+++ b/Prefabs/Weapons/Ammo/30x165/Ammo_30mm_HEFT_3UOR6.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{53A412B956DD26A4}Prefabs/Weapons/Ammo/30x165/Ammo_30mm_HEFT_3UOR6.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM16.et
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM16.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{F4A09B4A53606BCB}Prefabs/Weapons/Ammo/Ammo_APFSDS_HighCalibre_base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM16.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM16.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{575534567230CEC7}Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM16.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM42.et
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM42.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{F4A09B4A53606BCB}Prefabs/Weapons/Ammo/Ammo_APFSDS_HighCalibre_base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM42.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM42.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{25A7888DEDA2F943}Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDST_3BM42.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM15.et
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM15.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{F4A09B4A53606BCB}Prefabs/Weapons/Ammo/Ammo_APFSDS_HighCalibre_base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM15.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM15.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F14086F5170D1457}Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM15.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM29.et
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM29.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{F4A09B4A53606BCB}Prefabs/Weapons/Ammo/Ammo_APFSDS_HighCalibre_base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM29.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM29.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{AD0B5EF10A0DCA9C}Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_APFSDS_3BM29.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_HEFRAG_3OF26.et
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_HEFRAG_3OF26.et
@@ -1,0 +1,4 @@
+Projectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_HEFRAG_3OF26.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_HEFRAG_3OF26.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{F13841C887A6E200}Prefabs/Weapons/Ammo/Ammo_125x736/Ammo_125mm_HEFRAG_3OF26.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_127x108_APIT_BZT44.et
+++ b/Prefabs/Weapons/Ammo/Ammo_127x108_APIT_BZT44.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{158CA8519769A66F}Prefabs/Weapons/Ammo/SmallArms/Ammo_127x108_API_B32.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_127x108_APIT_BZT44.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_127x108_APIT_BZT44.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{27E671E1F169ED18}Prefabs/Weapons/Ammo/Ammo_127x108_APIT_BZT44.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_145x114_APIT_57BZT561S.et
+++ b/Prefabs/Weapons/Ammo/Ammo_145x114_APIT_57BZT561S.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{AF3D459E8AE71B58}Prefabs/Weapons/Ammo/SmallArms/Ammo_145x114_API_57BZ561S.et" {
+ ID "476AE74AA8E99E2E"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_145x114_APIT_57BZT561S.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_145x114_APIT_57BZT561S.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{DDC9BE44E2BD135B}Prefabs/Weapons/Ammo/Ammo_145x114_APIT_57BZT561S.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_145x114_IAI_7Z1.et
+++ b/Prefabs/Weapons/Ammo/Ammo_145x114_IAI_7Z1.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{AF3D459E8AE71B58}Prefabs/Weapons/Ammo/SmallArms/Ammo_145x114_API_57BZ561S.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_145x114_IAI_7Z1.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_145x114_IAI_7Z1.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{FBBF91CB9F696344}Prefabs/Weapons/Ammo/Ammo_145x114_IAI_7Z1.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_AP-T_3UBR6.et
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_AP-T_3UBR6.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{6DEC9F287271AB24}Prefabs/Weapons/Ammo/SmallArms/Ammo_127x99_AP_M2.et" {
+ ID "476AE74C1F2F140D"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_AP-T_3UBR6.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_AP-T_3UBR6.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{BA7EBCAA92439C60}Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_AP-T_3UBR6.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_APDS-T_3UBR8.et
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_APDS-T_3UBR8.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{6DEC9F287271AB24}Prefabs/Weapons/Ammo/SmallArms/Ammo_127x99_AP_M2.et" {
+ ID "476AE74C1F2F140D"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_APDS-T_3UBR8.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_APDS-T_3UBR8.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{0DF9FE819A9D3648}Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_APDS-T_3UBR8.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_HEF-I_3UOF8.et
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_HEF-I_3UOF8.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "476AE74C1F2F140D"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_HEF-I_3UOF8.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_HEF-I_3UOF8.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{6760C6582F09E5CD}Prefabs/Weapons/Ammo/Ammo_30x165/Ammo_30x165_HEF-I_3UOF8.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_545x39_Tracer_7T3.et
+++ b/Prefabs/Weapons/Ammo/Ammo_545x39_Tracer_7T3.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{1D9DDE1632F33A9E}Prefabs/Weapons/Ammo/SmallArms/Ammo_545x39_Ball_7N6.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_545x39_Tracer_7T3.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_545x39_Tracer_7T3.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{2BC4C9C3D171A53B}Prefabs/Weapons/Ammo/Ammo_545x39_Tracer_7T3.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HEAT_PG9.et
+++ b/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HEAT_PG9.et
@@ -1,0 +1,9 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "DA5C6308000CDEF2"
+ components {
+  RocketTraceEffectComponent "{69875A0CD46C18A7}" {
+   ParticleEffect "{0F364F4CD1D72350}Particles/Weapon/Trail_PG7VL.ptc"
+  }
+ }
+ ProjectileModel "{CA305BDAD273478A}Assets/Weapons/Magazines/RPG7/Rocket_PG7VM_item.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HEAT_PG9.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HEAT_PG9.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{BA51DB514BDBBC03}Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HEAT_PG9.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HE_OG9.et
+++ b/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HE_OG9.et
@@ -1,0 +1,8 @@
+TracerProjectile : "{67FED88E5085F63F}Prefabs/Weapons/Core/Ammo_Bullet_Base.et" {
+ ID "DA5C6308000CDEF2"
+ components {
+  RocketTraceEffectComponent "{69875A0CF6906FBB}" {
+   ParticleEffect "{0F364F4CD1D72350}Particles/Weapon/Trail_PG7VL.ptc"
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HE_OG9.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HE_OG9.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{9F1CBB3FF6A31A6A}Prefabs/Weapons/Ammo/Ammo_73x385/Ammo_73mm_HE_OG9.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_762x39_Tracer_57T231P.et
+++ b/Prefabs/Weapons/Ammo/Ammo_762x39_Tracer_57T231P.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{2FBCA0A7CEDDE7B0}Prefabs/Weapons/Ammo/SmallArms/Ammo_762x39_Ball_57N231.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_762x39_Tracer_57T231P.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_762x39_Tracer_57T231P.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{B9AB11A51D795EC5}Prefabs/Weapons/Ammo/Ammo_762x39_Tracer_57T231P.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_762x54r_Tracer_7T2.et
+++ b/Prefabs/Weapons/Ammo/Ammo_762x54r_Tracer_7T2.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{AC29AE3D5ECD6390}Prefabs/Weapons/Ammo/SmallArms/Ammo_762x54r_Ball_57N323S.et" {
+ ID "5272FB639B197E8B"
+ ProjectileModel "{141B6A1F89173504}Assets/Weapons/Ammo/Tracers/Tracer_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_762x54r_Tracer_7T2.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_762x54r_Tracer_7T2.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{279B4FEECCA799BD}Prefabs/Weapons/Ammo/Ammo_762x54r_Tracer_7T2.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}

--- a/Prefabs/Weapons/Ammo/Ammo_BaconZU23_23x152_HET_Tracer.et
+++ b/Prefabs/Weapons/Ammo/Ammo_BaconZU23_23x152_HET_Tracer.et
@@ -1,0 +1,4 @@
+TracerProjectile : "{AF3D459E8AE71B58}Prefabs/Weapons/Ammo/SmallArms/Ammo_145x114_API_57BZ561S.et" {
+ ID "DA5C6308000CDEF2"
+ ProjectileModel "{59A6D3C1A73FFF3E}Assets/Weapons/Ammo/Tracers/tracer_big_green.xob"
+}

--- a/Prefabs/Weapons/Ammo/Ammo_BaconZU23_23x152_HET_Tracer.et.meta
+++ b/Prefabs/Weapons/Ammo/Ammo_BaconZU23_23x152_HET_Tracer.et.meta
@@ -1,0 +1,19 @@
+MetaFileClass {
+ Name "{75A767F66044413A}Prefabs/Weapons/Ammo/Ammo_BaconZU23_23x152_HET_Tracer.et"
+ Configurations {
+  EntityTemplateResourceClass PC {
+  }
+  EntityTemplateResourceClass XBOX_ONE : PC {
+  }
+  EntityTemplateResourceClass XBOX_SERIES : PC {
+  }
+  EntityTemplateResourceClass PS4 : PC {
+  }
+  EntityTemplateResourceClass PS5 : PC {
+  }
+  EntityTemplateResourceClass HEADLESS : PC {
+  }
+  EntityTemplateResourceClass Xbox : PC {
+  }
+ }
+}


### PR DESCRIPTION
This changes the Warsaw Pact red tracers with green tracers. The changes are only done to the bullets. This will carry to any magazines that use those bullets. It includes 5.45, 7.62x39,7.62x54, 12.7mm, 14.5mm, 30mm, 125mm and adds rocket trails to the bmp-1 73mm rocket instead of the green tracer. 

Changed:                                                                                              |   Mod
127x108_APIT_BZT44 from yellow to green tracer                               | Vanilla Reforger
145x114_APIT_57BZT561S red to green tracer                                     | Vanilla Reforger
145x114_IAI_7Z1 red to green tracer                                                    | Vanilla Reforger
545x39_Tracer_7T3 red to green tracer                                                 | Vanilla Reforger
762x39_tracer_57T231P red to green tracer                                          | Vanilla Reforger
762x54r_tracer_7T2 red to green tracer                                                 | Vanilla Reforger
125mm_HE_frag_3OF26 red to green tracer                                          |   RHS and uses WCS armaments
125mm_APFSDST_3bM60 red to green tracer                                       |   RHS and uses WCS armaments
30x165 APT_3UBR6 red to green tracer                                                  |   RHS  and uses WCS armaments
30x165 HEFT_3UOR6 red to green tracer                                                |   RHS and uses WCS armaments
ZU23 23x152_ HET tracer   red to green tracer                                        |    ZU 23 and uses WCS armaments
Ammo_125mm_APFSDS_3BM15.et  larger green tracers                         |    Spacecore and uses WCS armaments
Ammo_125mm_APFSDS_3BM29.et   larger green tracers                         |    Spacecore and uses WCS armaments
Ammo_125mm_APFSDST_3BM16.et larger green tracers                         |    Spacecore and uses WCS armaments
Ammo_125mm_APFSDST_3BM42.et larger green tracers                         |    Spacecore and uses WCS armaments
Ammo_125mm_HEFRAG_3OF26.et  Had no tracer, added green tracer   |    Spacecore and uses WCS armaments
Ammo_73mm_HE_OG9.et    removed green tracer, added RocketTraceEffectComponent         |   SpaceCore
Ammo_73mm_HEAT_PG9.et removed green tracer, added RocketTraceEffectComponent         |   SpaceCore


Future goals: 
Create new ammo with red tracers and magazines that use them so mission makers can use them for Ex Warsaw Pact countries like the CDF. 